### PR TITLE
Fix/set-rates

### DIFF
--- a/.changeset/thin-panthers-sniff.md
+++ b/.changeset/thin-panthers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@torch-finance/simulator': patch
+---
+
+When calling `_setRates()`, if no rates are specified and the simulator already has a rate, it will return directly. Otherwise, it will calculate a default set of rates using decimals.

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -81,11 +81,10 @@ export class PoolSimulator implements IPoolSimulator {
   }
 
   private _setRates(rates?: Allocation[]): bigint[] {
-    if (rates === undefined) {
-      return this.decimals.map((d) => 10n ** BigInt(36 - d));
+    if (!rates) {
+      return this.rates || this.decimals.map((d) => 10n ** BigInt(36 - d));
     }
-    rates.sort((a, b) => a.compare(b));
-    return rates.map((rate) => rate.value);
+    return rates.sort((a, b) => a.compare(b)).map((rate) => rate.value);
   }
 
   private _xp(rates: bigint[]): bigint[] {


### PR DESCRIPTION
- Introduced logic in the _setRates method to return existing rates if none are specified, improving efficiency.
- If no rates are provided and the simulator lacks a rate, it now calculates a default set of rates using decimals.