### PR TITLE
feat(simulator): update claimAdminFees to accept optional rates parameter

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,7 +21,7 @@ export interface IPoolSimulator {
   deposit(depositParams: SimulateDepositParams): SimulatorDepositResult;
   swap(swapParams: SimulateSwapParams): SimulatorSwapResult;
   withdraw(withdrawParams: SimulateWithdrawParams): SimulateWithdrawResult;
-  claimAdminFees(): SimulatorDepositResult;
+  claimAdminFees(rates?: Allocation[]): SimulatorDepositResult;
   rampA(futureA: number, futureATime: number, nowBeforeRampA: number): void;
   stopRampA(now: number): void;
   swapExactOut(swapExactOutParams: SimulateSwapParams): bigint;

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -181,8 +181,10 @@ export class PoolSimulator implements IPoolSimulator {
     return this._deposit(amounts);
   }
 
-  claimAdminFees(): SimulatorDepositResult {
-    // Convert to bigint[]
+  claimAdminFees(rates?: Allocation[]): SimulatorDepositResult {
+    this.rates = this._setRates(rates);
+
+    // Convert admin fees to deposit
     const depositAmounts = this.adminFees.map((fee) => fee);
     // init adminFees
     this.adminFees = Array(this.poolAssetCount).fill(BigInt(0));


### PR DESCRIPTION
- Modified the IPoolSimulator interface to allow an optional rates parameter in the claimAdminFees method.
- Updated the PoolSimulator implementation to handle the new rates parameter, enhancing the functionality for managing admin fees.
- This change improves flexibility in fee calculations by allowing custom rate inputs.