### PR TITLE
Chore/dex-wrapper-type

### DIFF
--- a/.changeset/nice-buses-shave.md
+++ b/.changeset/nice-buses-shave.md
@@ -1,0 +1,6 @@
+---
+'@torch-finance/simulator': patch
+---
+
+- Update the params and result types of the simulator to be imported from dex-contract-wrapper.
+- Add vpBefore and vpAfter fields in swapExactOut.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: 'daily'
     allow:
       - dependency-name: '@torch-finance/core'
+      - dependency-name: '@torch-finance/dex-contract-wrapper'

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This is the SDK for @torch-finance/simulator.
 To start using this SDK:
 
 ```bash
-pnpm install @torch-finance/core @torch-finance/simulator
+pnpm install @torch-finance/core @torch-finance/dex-contract-wrapper
+pnpm install@torch-finance/simulator
 ```

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@ton/crypto": "^3.3.0",
     "@ton/ton": "^15.1.0",
     "@torch-finance/core": "^1.3.0",
+    "@torch-finance/dex-contract-wrapper": "^0.2.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
@@ -65,6 +66,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@torch-finance/core": ">=1.2.1"
+    "@torch-finance/core": ">=1.3.0",
+    "@torch-finance/dex-contract-wrapper": ">=0.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@torch-finance/core':
         specifier: ^1.3.0
         version: 1.3.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(zod@3.24.1)
+      '@torch-finance/dex-contract-wrapper':
+        specifier: ^0.2.0
+        version: 0.2.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@torch-finance/core@1.3.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(zod@3.24.1))(zod@3.24.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -770,6 +773,16 @@ packages:
       '@ton/core': '>=0.59.1'
       '@ton/crypto': '>=3.3.0'
       '@ton/ton': '>=15.1.0'
+      zod: '>=3.24.1'
+
+  '@torch-finance/dex-contract-wrapper@0.2.0':
+    resolution: {integrity: sha512-0B7GYJ91a0eb9muE2AHYWqQ47Z1dG3DR+gjFUZeXP15/ul6ZqrfZjMMCqHzJE58N7+ZkLwSxj9N9/8ou/1BE1A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@ton/core': '>=0.59.1'
+      '@ton/crypto': '>=3.3.0'
+      '@ton/ton': '>=15.1.0'
+      '@torch-finance/core': '>=1.3.0'
       zod: '>=3.24.1'
 
   '@types/babel__core@7.20.5':
@@ -3223,6 +3236,14 @@ snapshots:
       '@ton/core': 0.59.1(@ton/crypto@3.3.0)
       '@ton/crypto': 3.3.0
       '@ton/ton': 15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)
+      zod: 3.24.1
+
+  '@torch-finance/dex-contract-wrapper@0.2.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@torch-finance/core@1.3.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(zod@3.24.1))(zod@3.24.1)':
+    dependencies:
+      '@ton/core': 0.59.1(@ton/crypto@3.3.0)
+      '@ton/crypto': 3.3.0
+      '@ton/ton': 15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)
+      '@torch-finance/core': 1.3.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.1.0(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(zod@3.24.1)
       zod: 3.24.1
 
   '@types/babel__core@7.20.5':

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,13 +1,13 @@
 import { Allocation, Asset } from '@torch-finance/core';
 import {
-  SimulatorDepositResult,
-  SimulatorSwapResult,
-  SimulateWithdrawResult,
-  SimulatorSnapshot,
   SimulateDepositParams,
+  SimulateDepositResult,
   SimulateSwapParams,
+  SimulateSwapResult,
   SimulateWithdrawParams,
-} from './types';
+  SimulateWithdrawResult,
+} from '@torch-finance/dex-contract-wrapper';
+import { SimulatorSnapshot } from './types';
 
 export interface IPoolSimulator {
   getA(): number;
@@ -18,13 +18,12 @@ export interface IPoolSimulator {
   getY(i: number, j: number, x: bigint, xp: bigint[]): bigint;
   getYD(i: number, xp: bigint[], d: bigint): bigint;
   dy(i: number, j: number, dx: bigint, rates: bigint[]): bigint;
-  deposit(depositParams: SimulateDepositParams): SimulatorDepositResult;
-  swap(swapParams: SimulateSwapParams): SimulatorSwapResult;
+  deposit(depositParams: SimulateDepositParams): SimulateDepositResult;
+  swap(swapParams: SimulateSwapParams): SimulateSwapResult;
   withdraw(withdrawParams: SimulateWithdrawParams): SimulateWithdrawResult;
-  claimAdminFees(rates?: Allocation[]): SimulatorDepositResult;
+  claimAdminFees(rates?: Allocation[]): SimulateDepositResult;
   rampA(futureA: number, futureATime: number, nowBeforeRampA: number): void;
   stopRampA(now: number): void;
-  swapExactOut(swapExactOutParams: SimulateSwapParams): bigint;
   saveSnapshot(): SimulatorSnapshot;
   restoreSnapshot(state: SimulatorSnapshot): void;
 }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -376,6 +376,7 @@ export class PoolSimulator implements IPoolSimulator {
     const j = this.getIndex(swapExactOutParams.assetOut);
 
     this.rates = this._setRates(swapExactOutParams.rates);
+    const vpBefore = this.getVirtualPrice();
 
     const xp = this._xp(this.rates);
     const _dy = swapExactOutParams.amountOut;
@@ -384,11 +385,21 @@ export class PoolSimulator implements IPoolSimulator {
 
     const x = this.getY(j, i, yAfterTrade, xp);
     const dx = ((x - xp[i]) * PRECISION) / this.rates[i];
+
+    // Use swap exact out result to swap exact in to simulate and get virtual price after
+    const vpAfter = this._swapExactIn({
+      mode: 'ExactIn',
+      assetIn: swapExactOutParams.assetIn,
+      assetOut: swapExactOutParams.assetOut,
+      amountIn: dx,
+      rates: swapExactOutParams.rates,
+    }).virtualPriceAfter;
+
     return {
       mode: 'ExactOut',
       amountIn: dx,
-      virtualPriceAfter: 0n,
-      virtualPriceBefore: 0n,
+      virtualPriceBefore: vpBefore,
+      virtualPriceAfter: vpAfter,
     };
   }
 
@@ -519,6 +530,8 @@ export class PoolSimulator implements IPoolSimulator {
       futureA: this.futureA,
       initATime: this.initATime,
       futureATime: this.futureATime,
+      feeNumerator: this.feeNumerator,
+      adminFeeNumerator: this.adminFeeNumerator,
       now: this.now,
       reserves: this.balances,
       adminFees: this.adminFees,
@@ -532,6 +545,8 @@ export class PoolSimulator implements IPoolSimulator {
     this.futureA = state.futureA;
     this.initATime = state.initATime;
     this.futureATime = state.futureATime;
+    this.feeNumerator = state.feeNumerator;
+    this.adminFeeNumerator = state.adminFeeNumerator;
     this.now = state.now;
     this.balances = state.reserves;
     this.adminFees = state.adminFees;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,41 +1,41 @@
-import { Allocation, Asset } from '@torch-finance/core';
+import { Allocation } from '@torch-finance/core';
 
-export type SimulateDepositParams = {
-  depositAmounts: Allocation[]; // amount of tokens to be deposited
-  rates?: Allocation[]; // external rates for yield bearing stable pool
-};
+// export type SimulateDepositParams = {
+//   depositAmounts: Allocation[]; // amount of tokens to be deposited
+//   rates?: Allocation[]; // external rates for yield bearing stable pool
+// };
 
-export type SimulatorDepositResult = {
-  lpTokenOut: bigint; // amount of lp tokens minted
-  virtualPriceBefore: bigint; // virtual price before deposit
-  virtualPriceAfter: bigint; // virtual price after deposit
-  lpTotalSupply: bigint; // total supply of lp tokens
-};
+// export type SimulatorDepositResult = {
+//   lpTokenOut: bigint; // amount of lp tokens minted
+//   virtualPriceBefore: bigint; // virtual price before deposit
+//   virtualPriceAfter: bigint; // virtual price after deposit
+//   lpTotalSupply: bigint; // total supply of lp tokens
+// };
 
-export type SimulateSwapParams = {
-  assetIn: Asset; // asset to be swapped in
-  assetOut: Asset; // asset to be swapped out
-  amount: bigint; // amount of asset to be swapped
-  rates?: Allocation[]; // external rates for yield bearing stable pool
-};
+// export type SimulateSwapParams = {
+//   assetIn: Asset; // asset to be swapped in
+//   assetOut: Asset; // asset to be swapped out
+//   amount: bigint; // amount of asset to be swapped
+//   rates?: Allocation[]; // external rates for yield bearing stable pool
+// };
 
-export type SimulatorSwapResult = {
-  amountOut: bigint; // amount of asset received
-  virtualPriceBefore: bigint; // virtual price before swap
-  virtualPriceAfter: bigint; // virtual price after swap
-};
+// export type SimulatorSwapResult = {
+//   amountOut: bigint; // amount of asset received
+//   virtualPriceBefore: bigint; // virtual price before swap
+//   virtualPriceAfter: bigint; // virtual price after swap
+// };
 
-export type SimulateWithdrawParams = {
-  lpAmount: bigint; // amount of lp tokens to be burned
-  assetOut?: Asset; // asset to be withdrawn
-  rates?: Allocation[]; // external rates for yield bearing stable pool
-};
+// export type SimulateWithdrawParams = {
+//   lpAmount: bigint; // amount of lp tokens to be burned
+//   assetOut?: Asset; // asset to be withdrawn
+//   rates?: Allocation[]; // external rates for yield bearing stable pool
+// };
 
-export type SimulateWithdrawResult = {
-  amountOuts: bigint[]; // amount of assets received
-  virtualPriceBefore: bigint; // virtual price before withdraw
-  virtualPriceAfter: bigint; // virtual price after withdraw
-};
+// export type SimulateWithdrawResult = {
+//   amountOuts: bigint[]; // amount of assets received
+//   virtualPriceBefore: bigint; // virtual price before withdraw
+//   virtualPriceAfter: bigint; // virtual price after withdraw
+// };
 
 export interface SimulatorState {
   initA: number; // initial amplification coefficient

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,42 +1,5 @@
 import { Allocation } from '@torch-finance/core';
 
-// export type SimulateDepositParams = {
-//   depositAmounts: Allocation[]; // amount of tokens to be deposited
-//   rates?: Allocation[]; // external rates for yield bearing stable pool
-// };
-
-// export type SimulatorDepositResult = {
-//   lpTokenOut: bigint; // amount of lp tokens minted
-//   virtualPriceBefore: bigint; // virtual price before deposit
-//   virtualPriceAfter: bigint; // virtual price after deposit
-//   lpTotalSupply: bigint; // total supply of lp tokens
-// };
-
-// export type SimulateSwapParams = {
-//   assetIn: Asset; // asset to be swapped in
-//   assetOut: Asset; // asset to be swapped out
-//   amount: bigint; // amount of asset to be swapped
-//   rates?: Allocation[]; // external rates for yield bearing stable pool
-// };
-
-// export type SimulatorSwapResult = {
-//   amountOut: bigint; // amount of asset received
-//   virtualPriceBefore: bigint; // virtual price before swap
-//   virtualPriceAfter: bigint; // virtual price after swap
-// };
-
-// export type SimulateWithdrawParams = {
-//   lpAmount: bigint; // amount of lp tokens to be burned
-//   assetOut?: Asset; // asset to be withdrawn
-//   rates?: Allocation[]; // external rates for yield bearing stable pool
-// };
-
-// export type SimulateWithdrawResult = {
-//   amountOuts: bigint[]; // amount of assets received
-//   virtualPriceBefore: bigint; // virtual price before withdraw
-//   virtualPriceAfter: bigint; // virtual price after withdraw
-// };
-
 export interface SimulatorState {
   initA: number; // initial amplification coefficient
   futureA: number; // future amplification coefficient

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,15 @@
 import { Allocation } from '@torch-finance/core';
 
-export interface SimulatorState {
+interface SimulatorConfig {
   initA: number; // initial amplification coefficient
   futureA: number; // future amplification coefficient
   initATime: number; // initial time of amplification coefficient
   futureATime: number; // future time of amplification coefficient
   feeNumerator: number; // fee numerator
   adminFeeNumerator: number; // admin fee numerator
+}
+
+export interface SimulatorState extends SimulatorConfig {
   adminFees: Allocation[]; // admin fees
   reserves: Allocation[]; // reserves
   lpTotalSupply: bigint; // total supply of lp tokens
@@ -14,11 +17,7 @@ export interface SimulatorState {
   rates?: Allocation[]; // external rates for yield bearing stable pool
 }
 
-export interface SimulatorSnapshot {
-  initA: number; // initial amplification coefficient
-  futureA: number; // future amplification coefficient
-  initATime: number; // initial time of amplification coefficient
-  futureATime: number; // future time of amplification coefficient
+export interface SimulatorSnapshot extends SimulatorConfig {
   now: number; // current time
   adminFees: bigint[]; // admin fees
   reserves: bigint[]; // reserves


### PR DESCRIPTION
Updated the simulator to params and result types from dex-contract-wrapper and added vpBefore and vpAfter fields to swapExactOut.